### PR TITLE
Update required Markdown version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-Markdown==2.6.8
+Markdown>=2.6.8, <3

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'Topic :: Utilities'
     ],
     install_requires = [
-        'Markdown==2.6.8'
+        'Markdown>=2.6.8, <3'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
As mentioned in #5, vmd seems to work fine with Markdown at least up to 2.6.11.

This pull request broadens the version requirement, making it possible to package vmd on distros which have Markdown != 2.6.8.
